### PR TITLE
fix(ex2): inline scenario fallback to support file:// open

### DIFF
--- a/ex2/leadership-dilemma/game.js
+++ b/ex2/leadership-dilemma/game.js
@@ -1,3 +1,80 @@
+const FALLBACK_SCENARIOS = [
+  {
+    id: "communication-crisis",
+    title: "沟通危机：周例会上突发误解",
+    text:
+      "市场负责人公开质疑你承诺的上线日期，说技术团队从未同步过最新延期计划，现场气氛骤冷。",
+    options: [
+      {
+        text: "马上澄清并把责任推给技术经理，强调自己已经反复提醒。",
+        effects: { trust: -2, clarity: 0, results: -1 },
+        feedback:
+          "短期内甩锅减轻压力，但会削弱团队信任与责任心，冲突难以真正解决。",
+      },
+      {
+        text: "请市场和技术负责人复盘事实，承认信息断层，并提议下午开同步会。",
+        effects: { trust: 1, clarity: 2, results: 1 },
+        feedback: "坦诚承认缺口并安排复盘，有助于重建信任与明确下一步。",
+      },
+      {
+        text: "宣布暂缓讨论，承诺 24 小时内给出书面说明，先结束会议。",
+        effects: { trust: 0, clarity: 1, results: 0 },
+        feedback: "先稳住现场可避免情绪升级，但需要尽快给出透明方案。",
+      },
+    ],
+  },
+  {
+    id: "delegation-coaching",
+    title: "授权与辅导：新人主管独立带项目",
+    text:
+      "你把一个跨团队推广项目交给刚晋升的运营主管，但她迟迟没有推进关键里程碑。",
+    options: [
+      {
+        text: "直接重新收回项目并亲自主导，保证节点不再拖延。",
+        effects: { trust: -1, clarity: 1, results: 1 },
+        feedback: "短期确保交付，但会打击主管信心，也削弱团队授权文化。",
+      },
+      {
+        text: "约她一对一，先听她的困难，再共同拆解优先级与资源需求。",
+        effects: { trust: 2, clarity: 1, results: 1 },
+        feedback:
+          "倾听+共创计划能提升心理安全与目标清晰度，有助于培养独当一面的能力。",
+      },
+      {
+        text: "要求她下周提交详细计划，强调延误将影响奖金，务必自行解决。",
+        effects: { trust: -1, clarity: 2, results: 0 },
+        feedback: "明确期望与压力能推动执行，但缺少支持易让她感到孤立。",
+      },
+    ],
+  },
+  {
+    id: "cross-functional-conflict",
+    title: "跨部门冲突：客户定制需求",
+    text:
+      "大客户提出定制功能，销售承诺两周交付，研发却认为至少要一个月。双方已多次争执。",
+    options: [
+      {
+        text: "要求销售无条件按研发评估延后，并向客户致歉。",
+        effects: { trust: 0, clarity: 1, results: -1 },
+        feedback:
+          "支持研发可以守住质量，但若不提供替代方案，客户体验会受损。",
+      },
+      {
+        text: "召集三方快速对齐，拆解必需与可选功能，协商阶段性交付方案。",
+        effects: { trust: 2, clarity: 2, results: 2 },
+        feedback:
+          "促成共创并明确阶段目标，既守住信任也兼顾交付结果。",
+      },
+      {
+        text: "要求销售承担超售责任，研发暂时按原计划执行，后续再讨论。",
+        effects: { trust: -1, clarity: 0, results: 0 },
+        feedback:
+          "先压下争议但缺乏解决方案，冲突可能再次爆发。",
+      },
+    ],
+  },
+];
+
 const progressEl = document.getElementById("progress");
 const scenarioTitleEl = document.getElementById("scenario-title");
 const scenarioTextEl = document.getElementById("scenario-text");
@@ -36,9 +113,11 @@ const REFLECTION_QUESTIONS = [
   "要确保执行落地，你下一步准备和谁对齐、如何跟进？",
 ];
 
+let fallbackNoticeShown = false;
+
 async function loadScenarios() {
   try {
-    const response = await fetch(new URL("scenarios.json", window.location.href));
+    const response = await fetch("scenarios.json");
     if (!response.ok) {
       throw new Error(`无法读取情境：${response.status}`);
     }
@@ -49,87 +128,30 @@ async function loadScenarios() {
     return data;
   } catch (error) {
     console.warn("读取 scenarios.json 失败，使用内置数据。", error);
-    return fallbackScenarios();
+    showFallbackNotice();
+    return FALLBACK_SCENARIOS;
   }
 }
 
-function fallbackScenarios() {
-  return [
-    {
-      id: "communication-crisis",
-      title: "沟通危机：周例会上突发误解",
-      text: "市场负责人公开质疑你承诺的上线日期，说技术团队从未同步过最新延期计划，现场气氛骤冷。",
-      options: [
-        {
-          text: "马上澄清并把责任推给技术经理，强调自己已经反复提醒。",
-          effects: { trust: -2, clarity: 0, results: -1 },
-          feedback:
-            "短期内甩锅减轻压力，但会削弱团队信任与责任心，冲突难以真正解决。",
-        },
-        {
-          text: "请市场和技术负责人复盘事实，承认信息断层，并提议下午开同步会。",
-          effects: { trust: 1, clarity: 2, results: 1 },
-          feedback:
-            "坦诚承认缺口并安排复盘，有助于重建信任与明确下一步。",
-        },
-        {
-          text: "宣布暂缓讨论，承诺 24 小时内给出书面说明，先结束会议。",
-          effects: { trust: 0, clarity: 1, results: 0 },
-          feedback:
-            "先稳住现场可避免情绪升级，但需要尽快给出透明方案。",
-        },
-      ],
-    },
-    {
-      id: "delegation-coaching",
-      title: "授权与辅导：新人主管独立带项目",
-      text: "你把一个跨团队推广项目交给刚晋升的运营主管，但她迟迟没有推进关键里程碑。",
-      options: [
-        {
-          text: "直接重新收回项目并亲自主导，保证节点不再拖延。",
-          effects: { trust: -1, clarity: 1, results: 1 },
-          feedback: "短期确保交付，但会打击主管信心，也削弱团队授权文化。",
-        },
-        {
-          text: "约她一对一，先听她的困难，再共同拆解优先级与资源需求。",
-          effects: { trust: 2, clarity: 1, results: 1 },
-          feedback:
-            "倾听+共创计划能提升心理安全与目标清晰度，有助于培养独当一面的能力。",
-        },
-        {
-          text: "要求她下周提交详细计划，强调延误将影响奖金，务必自行解决。",
-          effects: { trust: -1, clarity: 2, results: 0 },
-          feedback:
-            "明确期望与压力能推动执行，但缺少支持易让她感到孤立。",
-        },
-      ],
-    },
-    {
-      id: "cross-functional-conflict",
-      title: "跨部门冲突：客户定制需求",
-      text: "大客户提出定制功能，销售承诺两周交付，研发却认为至少要一个月。双方已多次争执。",
-      options: [
-        {
-          text: "要求销售无条件按研发评估延后，并向客户致歉。",
-          effects: { trust: 0, clarity: 1, results: -1 },
-          feedback:
-            "支持研发可以守住质量，但若不提供替代方案，客户体验会受损。",
-        },
-        {
-          text: "召集三方快速对齐，拆解必需与可选功能，协商阶段性交付方案。",
-          effects: { trust: 2, clarity: 2, results: 2 },
-          feedback:
-            "促成共创并明确阶段目标，既守住信任也兼顾交付结果。",
-        },
-        {
-          text: "要求销售承担超售责任，研发暂时按原计划执行，后续再讨论。",
-          effects: { trust: -1, clarity: 0, results: 0 },
-          feedback:
-            "先压下争议但缺乏解决方案，冲突可能再次爆发。",
-        },
-      ],
-    },
-  ];
+function showFallbackNotice() {
+  if (fallbackNoticeShown) return;
+  const app = document.querySelector(".app");
+  if (!app) return;
+
+  const notice = document.createElement("div");
+  notice.textContent = "正在使用内置情境数据（本地打开模式）";
+  notice.setAttribute("role", "status");
+  notice.style.padding = "8px 12px";
+  notice.style.marginBottom = "8px";
+  notice.style.border = "1px solid #ffe58f";
+  notice.style.backgroundColor = "#fffbe6";
+  notice.style.color = "#7c6f1b";
+  notice.style.fontSize = "14px";
+  notice.style.borderRadius = "6px";
+  notice.style.textAlign = "center";
+
+  app.insertBefore(notice, app.firstChild);
+  fallbackNoticeShown = true;
 }
 
 function resetGame() {


### PR DESCRIPTION
## Summary
- inline the three leadership dilemma scenarios as FALLBACK_SCENARIOS in `game.js`
- keep using `fetch('scenarios.json')` when available and fall back to the inline data with a light notice when running via `file://`

## Testing
- not run (UI change)

> 本地调试：直接双击 `index.html` 以 `file://` 方式打开页面，若浏览器阻止读取 `scenarios.json` 会自动切换到内置情境并在顶部提示。


------
https://chatgpt.com/codex/tasks/task_e_68e508ad7164832293d7be3a7d1847e2